### PR TITLE
長いタイトルがレイアウトを崩さないようにした

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -37,6 +37,8 @@ img{
 }
 
 .comic{
+  height: 350px;
+    width: 475px;
     background-color: red;
     color: white;
     border-radius: 20px;
@@ -48,6 +50,7 @@ img{
 .comic p{
     padding-left: 10px;
     font-weight: bold;
+    font-size: 16px;
 }
 
 .comic:hover{


### PR DESCRIPTION
#8 に関する修正。
作品ごとのwidthを設定し、長いタイトルが改行されるようにした。
また、この対応に伴い作品ごとの高さを指定し、フォントサイズに関しても変更を加えた。