### PR TITLE
ユーザと作品の関連付けをしてユーザの設定が保持できるようになった

### DIFF
--- a/app/controllers/setting_controller.rb
+++ b/app/controllers/setting_controller.rb
@@ -9,6 +9,7 @@ class SettingController < ApplicationController
     user=User.find(session[:user])
     ids=[]
 
+    user.comics.clear # 既に登録された関連を一旦削除
     params[:check].each do |id,check|
       if check=="1"
         ids.push(id)

--- a/app/controllers/setting_controller.rb
+++ b/app/controllers/setting_controller.rb
@@ -6,11 +6,16 @@ class SettingController < ApplicationController
   end
 
   def post
+    user=User.find(session[:user])
+    ids=[]
+
     params[:check].each do |id,check|
       if check=="1"
-        comic=Comic.find_by(id:id)
-        puts(comic.title)
+        ids.push(id)
       end
     end
+
+    user.comics << Comic.find(ids)
+    user.save
   end
 end

--- a/app/models/comic.rb
+++ b/app/models/comic.rb
@@ -1,5 +1,6 @@
 class Comic < ApplicationRecord
   belongs_to :site
+  has_and_belongs_to_many :users
 
   validates :title, {presence: true}
   validates :url, {presence: true}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,2 +1,3 @@
 class User < ApplicationRecord
+  has_and_belongs_to_many :comics
 end

--- a/db/migrate/20181128073612_create_comics_users.rb
+++ b/db/migrate/20181128073612_create_comics_users.rb
@@ -1,0 +1,8 @@
+class CreateComicsUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :comics_users,id: false do |t|
+      t.references :comic, foreign_key: true,null: false
+      t.references :user, foreign_key: true,null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_27_025505) do
+ActiveRecord::Schema.define(version: 2018_11_28_073612) do
 
   create_table "comics", force: :cascade do |t|
     t.string "title"
@@ -19,6 +19,13 @@ ActiveRecord::Schema.define(version: 2018_11_27_025505) do
     t.integer "site_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "comics_users", id: false, force: :cascade do |t|
+    t.integer "comic_id", null: false
+    t.integer "user_id", null: false
+    t.index ["comic_id"], name: "index_comics_users_on_comic_id"
+    t.index ["user_id"], name: "index_comics_users_on_user_id"
   end
 
   create_table "sites", force: :cascade do |t|


### PR DESCRIPTION
#5 に関する変更。
user.idとcomic.idが多対多で関連付けられた。
これにより、ユーザの設定状態を表現する。