### PR TITLE
スクレイピングによるデータ更新時にタイトルとサイトで判断するように

### DIFF
--- a/lib/tasks/scrape_sundaywebry.rake
+++ b/lib/tasks/scrape_sundaywebry.rake
@@ -6,6 +6,7 @@ namespace :scrape_sundaywebry do
   task :scrape => :environment do
 
     url='https://www.sunday-webry.com/'
+    site_id=2
     charset=nil
 
     html=open(url) do |page|
@@ -35,8 +36,8 @@ namespace :scrape_sundaywebry do
         puts("-----------------------------------------")
 
         # DB更新
-        comic=Comic.find_or_initialize_by(title:title)
-        comic.update(title:title,url:url,thum_url:thum_url,site_id:2)
+        comic=Comic.find_or_initialize_by(title:title,site_id:site_id)
+        comic.update(title:title,url:url,thum_url:thum_url,site_id:site_id)
       end
     end
   end

--- a/lib/tasks/scrape_urasunday.rake
+++ b/lib/tasks/scrape_urasunday.rake
@@ -3,6 +3,7 @@ require 'open-uri'
 namespace :scrape_urasunday do
 
   desc '裏サンデーのwebサイトから更新情報を取得'
+  site_id=1
   task :scrape => :environment do
 
     url='https://urasunday.com/'
@@ -39,8 +40,8 @@ namespace :scrape_urasunday do
       puts("-----------------------------------------")
 
       # DB更新
-      comic=Comic.find_or_initialize_by(title:title)
-      comic.update(title:title,url:url,thum_url:thum_url,site_id:1)
+      comic=Comic.find_or_initialize_by(title:title,site_id:site_id)
+      comic.update(title:title,url:url,thum_url:thum_url,site_id:site_id)
     end
   end
 end

--- a/lib/tasks/scrape_yawaraka.rake
+++ b/lib/tasks/scrape_yawaraka.rake
@@ -3,6 +3,7 @@ require 'open-uri'
 namespace :scrape_yawaraka do
 
   desc 'やわらかスピリッツのwebサイトから更新情報を取得'
+  site_id=3
   task :scrape => :environment do
 
     url='http://yawaspi.com/'
@@ -45,8 +46,8 @@ namespace :scrape_yawaraka do
           puts("-----------------------------------------")
 
           # DB更新
-          comic=Comic.find_or_initialize_by(title:title)
-          comic.update(title:title,url:url,thum_url:thum_url,site_id:3)
+          comic=Comic.find_or_initialize_by(title:title,site_id:site_id)
+          comic.update(title:title,url:url,thum_url:thum_url,site_id:site_id)
         end
       end
     end


### PR DESCRIPTION
#22  に関する変更。
データ更新の要否をタイトルのみで判断していたことによる問題を修正。
タイトルとサイトによって判断するようになった。