### PR TITLE
設定ページの作品をハードコードしていたのを修正

### DIFF
--- a/app/controllers/setting_controller.rb
+++ b/app/controllers/setting_controller.rb
@@ -1,10 +1,14 @@
 class SettingController < ApplicationController
   def index
-    @us_comics=Comic.where(site_id:Site.find_by(name:'裏サンデー')[:id])
-    @sw_comics=Comic.where(site_id:Site.find_by(name:'サンデーうぇぶり')[:id])
-    @ys_comics=Comic.where(site_id:Site.find_by(name:'やわらかスピリッツ')[:id])
 
+    # サイトごとに作品取得
+    sites=Site.all
+    @comics=Hash.new()
+    sites.each do |site|
+      @comics[site.name]=Comic.where(site_id:site.id)
+    end
 
+    # ユーザがチェック済みの作品
     checked_comics=Comic.includes(:users).where('users.id'=>session[:user])
     @checked_comics_id=[]
     checked_comics.each do |comic|

--- a/app/views/setting/index.html.erb
+++ b/app/views/setting/index.html.erb
@@ -1,8 +1,11 @@
 <br /><br /><br /><br />
 
 <%= form_tag("/setting/post",method:"post") do%>
-  <h1>urasunday</h1>
-  <% @us_comics.each do |comic| %>
+
+  <% @comics.each do |site,site_comics|%>
+    <h1><%= site%></h1>
+
+    <% site_comics.each do |comic|%>
     <p>
       <% if @checked_comics_id.include?(comic.id)%>
         <%= check_box "check", comic.id,{:checked=>true}%>
@@ -11,30 +14,8 @@
       <% end%>
       <%= label_tag comic.id,comic.title%>
     </p>
-  <% end %>
-
-  <h1>sundaywebry</h1>
-  <% @sw_comics.each do |comic| %>
-  <p>
-    <% if @checked_comics_id.include?(comic.id)%>
-      <%= check_box "check", comic.id,{:checked=>true}%>
-    <% else%>
-      <%= check_box "check", comic.id%>
     <% end%>
-    <%= label_tag comic.id,comic.title%>
-  </p>
-  <% end %>
+  <% end%>
 
-  <h1>yawaraka</h1>
-  <% @ys_comics.each do |comic| %>
-  <p>
-    <% if @checked_comics_id.include?(comic.id)%>
-      <%= check_box "check", comic.id,{:checked=>true}%>
-    <% else%>
-      <%= check_box "check", comic.id%>
-    <% end%>
-    <%= label_tag comic.id,comic.title%>
-  </p>
-  <% end %>
   <button type="submit">ok</button>
 <% end %>


### PR DESCRIPTION
#28 に関する変更。
サイト名を明示せずに設定画面に表示する作品を引き出すようになった。
これにより、DBに存在しないサイト名を指定することで起きていたエラーが解消される。
また、今後対応サイトを増やす際もスクレイピングを追加するだけで対応できる。