### PR TITLE
Cookieに格納する値を変更した

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 class ApplicationController < ActionController::Base
 
   before_action :set_session
@@ -10,8 +12,9 @@ class ApplicationController < ActionController::Base
 
     # クッキーが無い時
     if !user?
-      new_user=User.create
-      new_user_id=new_user.id
+      uuid=SecureRandom.uuid
+      new_user=User.create(uuid:uuid)
+      new_user_id=new_user.uuid
       cookies.permanent[:user]=new_user_id
     end
 
@@ -21,7 +24,7 @@ class ApplicationController < ActionController::Base
     end
 
     # セッションが不正な時
-    if !User.find_by(id:session[:user])
+    if !User.find_by(uuid:session[:user])
       reset_session
       cookies.delete :user
       redirect_to("/session_error")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
 class User < ApplicationRecord
   has_and_belongs_to_many :comics
+  validates :uuid, {presence: true}
 end

--- a/db/migrate/20181207110643_add_users_uuid.rb
+++ b/db/migrate/20181207110643_add_users_uuid.rb
@@ -1,0 +1,5 @@
+class AddUsersUuid < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users,:uuid,:string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_11_28_073612) do
+ActiveRecord::Schema.define(version: 2018_12_07_110643) do
 
   create_table "comics", force: :cascade do |t|
     t.string "title"
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 2018_11_28_073612) do
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "uuid"
   end
 
 end


### PR DESCRIPTION
#16 に関する変更。
単純な連番で保存されていたidをuuidに変更した。
もともと衝突しない値であるため、直接見ない限りは特定しづらいと考え、暗号化はひとまず行わないこととした。
セキュリティに関する知識が浅いため間違った判断である可能性がある。今後の課題といえる。
