### PR TITLE
初回設定変更時にidを生成するようにした

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,19 +19,22 @@ class ApplicationController < ActionController::Base
   end
 
   def set_session
-    # セッションが無い時
-    if user? && !session[:user]
-      session[:user]=User.find_by(uuid:cookies[:user]).id
-    else
-      return
+    if user?
+      # クッキーが不正な時
+      if !User.find_by(uuid:cookies[:user])
+        reset_session
+        cookies.delete :user
+        redirect_to("/session_error")
+        return
+      end
+
+      # セッションが無い時
+      if !session[:user]
+        session[:user]=User.find_by(uuid:cookies[:user]).id
+      end
     end
 
-    # セッションが不正な時
-    if !User.find_by(id:session[:user])
-      reset_session
-      cookies.delete :user
-      redirect_to("/session_error")
-    end
+
 
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,8 +8,7 @@ class ApplicationController < ActionController::Base
     return cookies[:user]
   end
 
-  def set_session
-
+  def set_cookie
     # クッキーが無い時
     if !user?
       uuid=SecureRandom.uuid
@@ -17,14 +16,18 @@ class ApplicationController < ActionController::Base
       new_user_id=new_user.uuid
       cookies.permanent[:user]=new_user_id
     end
+  end
 
+  def set_session
     # セッションが無い時
-    if !session[:user]
-      session[:user]=cookies[:user]
+    if user? && !session[:user]
+      session[:user]=User.find_by(uuid:cookies[:user]).id
+    else
+      return
     end
 
     # セッションが不正な時
-    if !User.find_by(uuid:session[:user])
+    if !User.find_by(id:session[:user])
       reset_session
       cookies.delete :user
       redirect_to("/session_error")

--- a/app/controllers/setting_controller.rb
+++ b/app/controllers/setting_controller.rb
@@ -1,4 +1,7 @@
 class SettingController < ApplicationController
+  before_action :set_cookie,{only:[:post]}
+  before_action :set_session
+
   def index
 
     # サイトごとに作品取得
@@ -9,10 +12,12 @@ class SettingController < ApplicationController
     end
 
     # ユーザがチェック済みの作品
-    checked_comics=Comic.includes(:users).where('users.id'=>session[:user])
     @checked_comics_id=[]
-    checked_comics.each do |comic|
-      @checked_comics_id.push(comic.id)
+    if session[:user]
+      checked_comics=Comic.includes(:users).where('users.id'=>session[:user])
+      checked_comics.each do |comic|
+        @checked_comics_id.push(comic.id)
+      end
     end
 
   end


### PR DESCRIPTION
#17 に関する変更。
初めて設定を行った時にidが生成されるようになった。
初回アクセス時の生成では無駄なidが増えると感じたため。